### PR TITLE
init kubernetes-controllers

### DIFF
--- a/Docs/kube-l-1-2.md
+++ b/Docs/kube-l-1-2.md
@@ -1,0 +1,19 @@
+## В процессе сделано:
+ - Под kube-apiserver-minikube описан в /etc/kubernetes/manifests/kube-apiserver.yaml в папке манифестов Kubelet. Kubelet сам управляет этим Подом и поднимает, если он упал.
+ - Под coredns скорее всего поднимает scheduler, имеет опцию restartPolicy: Always, так как не нашел его в /etc/kubernetes/manifests/
+ - Создан образ app-web с web-сервером (python) отдает папку /app, слушает 8000, uid 1001, помещен в открытый репозиторий boroda747/app-web:v1  
+ - Написан манифест web-pod.yaml
+ - В манифест web-pod.yaml добавлен initContainer, который тянет index.html для web-pod.yaml. Добавлен volume app
+ - Создан образ frontend из предоставленного репозитория, помещен в boroda747/frontend:v1
+ - Запуск kubectl run ... frontend, pod не стартуер, ошибка "panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set", не хватает environments. Написан frontend-pod.yaml
+ - Написан frontend-pod-healthy.yaml, с добавлением нужных environments.
+
+## Как запустить проект:
+ - Запуск kubectl apply -f web-pod.yaml
+ - Проверка kubectl port-forward --address 0.0.0.0 pod/web 8000:8000. 
+ - Запуск kubectl run frontend --image boroda747/frontend:v1 --restart=Never или kubectl apply -f frontend-pod.yaml
+ - Применение правильного конфига kubectl apply -f frontend-pod-healthy.yaml
+
+## Как проверить работоспособность:
+ - Посмотреть kubectl get pods, что контейнер в статусе running
+ - Перейти по ссылке http://localhost:8000 или http://ip_host:8000

--- a/Docs/kube-l-1-3.md
+++ b/Docs/kube-l-1-3.md
@@ -1,9 +1,3 @@
-# Выполнено ДЗ №
-
- - [x] Основное ДЗ
- - [x] Задание со *
- - [x] Задание со **
-
 ## В процессе сделано:
  - Запущено окружение с помощью локального кластера kind
  - Создан манифест frontend-replicaset.yaml, добавлены образ с предыдущего задания и env
@@ -96,6 +90,3 @@ kubectl delete pods -l app=frontend | kubectl get pods -l app=frontend -w
  - Проверка образа в контейнерах kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'
  - История версий kubectl rollout history deployment paymentservice
  - Откат kubectl rollout undo deployment paymentservice --to-revision=1
-
-## PR checklist:
- - [x] Выставлен label с номером домашнего задания

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # idyukanov_platform
 idyukanov Platform repository
 
-- Добавлено kubernetesintro
+- [Добавлено kubernetes-intro](Docs/kube-l-1-2.md)
+- [Добавлено kubernetes-controllers](Docs/kube-l-1-3.md)

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: boroda747/frontend:v0.0.1
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              path: "/_healthz"
+              port: 8080
+              httpHeaders:
+              - name: "Cookie"
+                value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: frontend
+        image: boroda747/frontend:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/kind-config.yaml
+++ b/kubernetes-controllers/kind-config.yaml
@@ -1,0 +1,9 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+- role: control-plane
+- role: control-plane
+- role: control-plane
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers: 
+      - name: node-exporter
+        image: prom/node-exporter
+        ports:
+        - containerPort: 9100
+        args:
+        - --path.rootfs=/rootfs'
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: boroda747/paymentservice:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: boroda747/paymentservice:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: boroda747/paymentservice:v0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: paymentservice
+        image: boroda747/paymentservice:v0.0.1
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Под kube-apiserver-minikube описан в /etc/kubernetes/manifests/kube-apiserver.yaml в папке манифестов Kubelet. Kubelet сам управляет этим Подом и поднимает, если он упал.
 - Под coredns скорее всего поднимает scheduler, имеет опцию restartPolicy: Always, так как не нашел его в /etc/kubernetes/manifests/
 - Создан образ app-web с web-сервером (python) отдает папку /app, слушает 8000, uid 1001, помещен в открытый репозиторий boroda747/app-web:v1  
 - Написан манифест web-pod.yaml
 - В манифест web-pod.yaml добавлен initContainer, который тянет index.html для web-pod.yaml. Добавлен volume app
 - Создан образ frontend из предоставленного репозитория, помещен в boroda747/frontend:v1
 - Запуск kubectl run ... frontend, pod не стартуер, ошибка "panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set", не хватает environments. Написан frontend-pod.yaml
 - Написан frontend-pod-healthy.yaml, с добавлением нужных environments.

## Как запустить проект:
 - Запуск kubectl apply -f web-pod.yaml
 - Проверка kubectl port-forward --address 0.0.0.0 pod/web 8000:8000. 
 - Запуск kubectl run frontend --image boroda747/frontend:v1 --restart=Never или kubectl apply -f frontend-pod.yaml
 - Применение правильного конфига kubectl apply -f frontend-pod-healthy.yaml

## Как проверить работоспособность:
 - Посмотреть kubectl get pods, что контейнер в статусе running
 - Перейти по ссылке http://localhost:8000 или http://ip_host:8000

## PR checklist:
 - [ ] Выставлен label с номером домашнего задания